### PR TITLE
Add space in opening rp parenthesis

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -181,7 +181,7 @@ chunkToString ( text, ruby ) =
         text
 
     else
-        "<ruby>" ++ text ++ "<rp>(</rp><rt>" ++ ruby ++ "</rt><rp>)</rp></ruby>"
+        "<ruby>" ++ text ++ "<rp> (</rp><rt>" ++ ruby ++ "</rt><rp>)</rp></ruby>"
 
 
 update : Msg -> Model -> Model


### PR DESCRIPTION
If RP is used that renders as `text (annotation)` instead of `text(annotation)`.